### PR TITLE
Add ship sizes

### DIFF
--- a/src/config/ships.py
+++ b/src/config/ships.py
@@ -27,6 +27,9 @@ ROLE_ID_SILVERCLAW = 977935623774162954
 ROLE_ID_VENOM = 1237838106711822457
 ROLE_ID_TITAN = 1247405133130764329
 
+SIZE_2_SQUADS = 24
+SIZE_3_SQUADS = 33
+
 ###############################################################################
 # Ships - Ship objects
 ###############################################################################
@@ -36,71 +39,83 @@ SHIPS = [
         boat_command_channel_id=BC_LUSTY,
         role_id=ROLE_ID_LUSTY,
         emoji="<:Lusty:1079841997021524018>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Berserker",
         boat_command_channel_id=BC_BERSERKER,
         role_id=ROLE_ID_BERSERKER,
         emoji="<:Berserker:1390427238922719275>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Serenity",
         boat_command_channel_id=BC_SERENITY,
         role_id=ROLE_ID_SERENITY,
         emoji="<:Serenity:1356016930032713879>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Adun",
         boat_command_channel_id=BC_ADUN,
         role_id=ROLE_ID_ADUN,
         emoji="<:Adun:1251266293601013871>",
+        size=SIZE_3_SQUADS
     ),
     Ship(
         name="USS Gletsjer",
         boat_command_channel_id=BC_GLETSJER,
         role_id=ROLE_ID_GLETSJER,
         emoji="<:Gletsjer:1356717285171265818>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Hyperion",
         boat_command_channel_id=BC_HYPERION,
         role_id=ROLE_ID_HYPERION,
         emoji="<:hyperion1:1162043891185369199>",
+        size=SIZE_3_SQUADS,
     ),
     Ship(
         name="USS Nightingale",
         boat_command_channel_id=BC_NIGHTINGALE,
         role_id=ROLE_ID_NIGHTINGALE,
         emoji="<:nightingale:1382145592934924370>",
+        size=SIZE_3_SQUADS,
     ),
     Ship(
         name="USS Defiant",
         boat_command_channel_id=BC_ARIZONA,
         role_id=ROLE_ID_ARIZONA,
         emoji="<:Defiant:1354503521747075072>",
+        size=SIZE_3_SQUADS,
     ),
     Ship(
         name="USS Phantom",
         boat_command_channel_id=BC_PHANTOM,
         role_id=ROLE_ID_PHANTOM,
         emoji="<:Phantom:1375148736472158228>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Silverclaw",
         boat_command_channel_id=BC_SILVERCLAW,
         role_id=ROLE_ID_SILVERCLAW,
         emoji="<:Silverclaw_emoji:1345475394169475104>",
+        size=SIZE_3_SQUADS,
     ),
     Ship(
         name="USS Venom",
         boat_command_channel_id=BC_VENOM,
         role_id=ROLE_ID_VENOM,
         emoji="<:Venom:1239895956489633852>",
+        size=SIZE_2_SQUADS,
     ),
     Ship(
         name="USS Titan",
         boat_command_channel_id=BC_TITAN,
         role_id=ROLE_ID_TITAN,
         emoji="<:Titan:1352591957804978277>",
+        size=SIZE_2_SQUADS,
     ),
 ]

--- a/src/data/structs.py
+++ b/src/data/structs.py
@@ -18,6 +18,7 @@ class Ship:
     role_id: int = None # Role ID of the ship
     boat_command_channel_id: int = None # Channel ID of the ship's boat command channel (e.g. BC_VENOM)
     emoji: str = None # Emoji of the ship
+    size: int = 24
 
 @dataclass
 class Abbreviation:

--- a/src/data/structs.py
+++ b/src/data/structs.py
@@ -18,7 +18,7 @@ class Ship:
     role_id: int = None # Role ID of the ship
     boat_command_channel_id: int = None # Channel ID of the ship's boat command channel (e.g. BC_VENOM)
     emoji: str = None # Emoji of the ship
-    size: int = 24
+    size: int = 24 # Maximum size of the ship (number of people)
 
 @dataclass
 class Abbreviation:


### PR DESCRIPTION
Adds a size field to the Ship class. To be used with NRC `/placerecruit` now that each ship can have its own max size.

Marked as DRAFT since not all ships have responded to the most recent announcement about ship sizes.