### PR TITLE
Fix voyage log processing for missing Discord members

### DIFF
--- a/src/utils/rank_and_promotion_utils.py
+++ b/src/utils/rank_and_promotion_utils.py
@@ -4,16 +4,28 @@ import discord
 
 from src.config.ranks import RANKS
 from src.config.ranks_roles import E2_ROLES
-from src.data.structs import NavyRank, Award
+from src.data.structs import Award, NavyRank
 
 log = logging.getLogger(__name__)
+
+
+def _get_member_role_ids(target: discord.Member | None) -> set[int]:
+    """
+    Return role IDs for a guild member.
+
+    Discord may return None or a User object instead of a Member when a voyage log
+    mentions somebody who is no longer in the guild or is not cached. Those objects
+    do not expose roles, so callers should treat them as having no rank/award roles.
+    """
+    return {role.id for role in getattr(target, "roles", [])}
 
 
 def is_seaman_apprentice(target: discord.Member) -> bool:
     """
     Check if the member has the Seaman Apprentice role.
     """
-    return E2_ROLES[1] in [role.id for role in target.roles]
+    return E2_ROLES[1] in _get_member_role_ids(target)
+
 
 def get_next_award(
         target: discord.Member,
@@ -22,7 +34,7 @@ def get_next_award(
     """
     Given the current member, return the next award that the member will achieve.
     """
-    member_role_ids = [role.id for role in target.roles]
+    member_role_ids = _get_member_role_ids(target)
     member_awards = [award for award in category_awards if award.role_id in member_role_ids]
     highest_award = None
     for award in member_awards:
@@ -37,6 +49,7 @@ def get_next_award(
         return category_awards[0]
     return next_award
 
+
 def get_current_award(
         target: discord.Member,
         category_awards: [Award]
@@ -45,12 +58,13 @@ def get_current_award(
     Given the current member, return the award with the highest index that the member has.
     """
     highest_award = None
-    member_role_ids = [role.id for role in target.roles]
+    member_role_ids = _get_member_role_ids(target)
     member_awards = [award for award in category_awards if award.role_id in member_role_ids]
     for award in member_awards:
         if highest_award is None or award.threshold < highest_award.threshold:
             highest_award = award
     return highest_award
+
 
 def has_award_or_higher(
     target: discord.Member,
@@ -60,7 +74,7 @@ def has_award_or_higher(
     """
     Check if the target has the required award or higher.
     """
-    member_role_ids = [role.id for role in target.roles]
+    member_role_ids = _get_member_role_ids(target)
     member_awards = [award for award in category_awards if award.role_id in member_role_ids]
     required_threshold = required_award.threshold
     log.info(f"Checking if {target.display_name} has the required award or higher: {required_award}")
@@ -69,6 +83,7 @@ def has_award_or_higher(
             log.info(f"{target.display_name} has the required award or higher: {award} - {award.threshold} >= {required_threshold}")
             return True
 
+
 def get_current_rank(
         target: discord.Member
 ) -> NavyRank | None:
@@ -76,14 +91,15 @@ def get_current_rank(
     Given the current member, return the rank with the highest index that the member has.
     """
     highest_rank = None
+    member_role_ids = _get_member_role_ids(target)
     for rank in RANKS:
-        if any(role.id in rank.role_ids for role in target.roles):
+        if any(role_id in rank.role_ids for role_id in member_role_ids):
             if highest_rank is None or rank.index < highest_rank.index:
                 highest_rank = rank
     return highest_rank
 
 
-def get_current_rank_role_id(target: discord.Member) -> int | None:
+ def get_current_rank_role_id(target: discord.Member) -> int | None:
     """
     Given the current member, return the specific applicable role ID for their rank.
     """
@@ -96,12 +112,13 @@ def get_current_rank_role_id(target: discord.Member) -> int | None:
         return E2_ROLES[1]
 
     # Find the highest rank role ID the user actually possesses
-    member_role_ids = {role.id for role in target.roles}
+    member_role_ids = _get_member_role_ids(target)
     for role_id in highest_rank.role_ids:
         if role_id in member_role_ids:
             return role_id
 
     return None
+
 
 def get_rank_by_index(
         index: int

--- a/src/utils/rank_and_promotion_utils.py
+++ b/src/utils/rank_and_promotion_utils.py
@@ -99,7 +99,7 @@ def get_current_rank(
     return highest_rank
 
 
- def get_current_rank_role_id(target: discord.Member) -> int | None:
+def get_current_rank_role_id(target: discord.Member) -> int | None:
     """
     Given the current member, return the specific applicable role ID for their rank.
     """

--- a/tests/utils/test_rank_and_promotion_utils.py
+++ b/tests/utils/test_rank_and_promotion_utils.py
@@ -1,0 +1,22 @@
+import unittest
+from types import SimpleNamespace
+
+from src.utils.rank_and_promotion_utils import get_current_rank, get_current_rank_role_id
+
+
+class TestRankAndPromotionUtils(unittest.TestCase):
+    def test_get_current_rank_returns_none_for_missing_guild_member(self):
+        self.assertIsNone(get_current_rank(None))
+
+    def test_get_current_rank_returns_none_for_user_without_roles(self):
+        user = SimpleNamespace(id=123)
+
+        self.assertIsNone(get_current_rank(user))
+
+    def test_get_current_rank_role_id_returns_none_for_missing_guild_member(self):
+        self.assertIsNone(get_current_rank_role_id(None))
+
+    def test_get_current_rank_role_id_returns_none_for_user_without_roles(self):
+        user = SimpleNamespace(id=123)
+
+        self.assertIsNone(get_current_rank_role_id(user))


### PR DESCRIPTION
## Summary
- Add a safe role-id helper for rank/award lookups so missing guild members or Discord `User` objects without `roles` are treated as having no roles.
- Reuse the helper in rank and award lookup paths.
- Add regression tests covering `None` members and user-like objects without `roles`.

## Context
The production alert showed voyage log reprocessing failing with `AttributeError: 'NoneType' object has no attribute 'roles'` / `User object has no attribute 'roles'`. This happens when `Process_Voyage_Log` asks `get_current_rank_role_id(member)` for a mentioned participant whose guild member object cannot be resolved.

## Tests
- Not run locally; changes were made through GitHub connector.